### PR TITLE
Support remote execution of tunnel installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Installation du tunnel Cloudflare sur Proxmox
+
+Ce dépôt contient un script shell permettant d'installer rapidement le tunnel Cloudflare sur une machine virtuelle Proxmox.
+
+## Script d'installation
+
+Le script principal se trouve dans `scripts/install_cloudflare_tunnel.sh`.
+
+### Pré-requis
+- Exécuter le script en tant que `root` (ou avec `sudo`).
+- Optionnel : définir la variable d'environnement `CLOUDFLARE_TUNNEL_TOKEN` avec le jeton généré depuis le tableau de bord Cloudflare pour installer automatiquement le service.
+
+### Utilisation
+```bash
+sudo ./scripts/install_cloudflare_tunnel.sh
+```
+
+Vous pouvez également exécuter le script à distance sans le télécharger au préalable :
+
+```bash
+sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/sdavid66/omv-proxmox-swiss/main/scripts/install_cloudflare_tunnel.sh)"
+```
+
+Pour installer directement le service `cloudflared` avec votre tunnel :
+
+```bash
+export CLOUDFLARE_TUNNEL_TOKEN="<votre_jeton>"
+sudo ./scripts/install_cloudflare_tunnel.sh
+```
+
+Ou à distance en une seule commande :
+
+```bash
+sudo CLOUDFLARE_TUNNEL_TOKEN="<votre_jeton>" bash -c "$(curl -fsSL https://raw.githubusercontent.com/sdavid66/omv-proxmox-swiss/main/scripts/install_cloudflare_tunnel.sh)"
+```
+
+Le script affiche chaque étape de l'installation, installe les dépendances requises, ajoute le dépôt officiel Cloudflare, installe `cloudflared` puis affiche l'adresse IP locale de la machine pour identifier l'agent.

--- a/scripts/install_cloudflare_tunnel.sh
+++ b/scripts/install_cloudflare_tunnel.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND="noninteractive"
+
+LOG_PREFIX="[Cloudflare Tunnel Installer]"
+
+step() {
+  echo -e "\n${LOG_PREFIX} ==> $1"
+}
+
+require_root() {
+  if [[ "${EUID}" -ne 0 ]]; then
+    echo "${LOG_PREFIX} Ce script doit être exécuté en tant que root." >&2
+    exit 1
+  fi
+}
+
+install_dependencies() {
+  step "Mise à jour des paquets système"
+  apt-get update
+
+  step "Installation des dépendances requises (curl, gnupg, lsb-release)"
+  apt-get install -y --no-install-recommends curl gnupg lsb-release ca-certificates
+}
+
+add_cloudflare_repository() {
+  step "Ajout de la clé GPG Cloudflare"
+  install -d -m 0755 /usr/share/keyrings
+  curl -fsSL https://pkg.cloudflare.com/GPG.KEY | gpg --dearmor -o /usr/share/keyrings/cloudflare-main.gpg
+
+  step "Ajout du dépôt Cloudflare à APT"
+  cat <<EOF > /etc/apt/sources.list.d/cloudflare-main.list
+deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/ $(lsb_release -cs) main
+EOF
+}
+
+install_cloudflared() {
+  step "Actualisation des index APT avec le dépôt Cloudflare"
+  apt-get update
+
+  step "Installation du paquet cloudflared"
+  apt-get install -y --no-install-recommends cloudflared
+}
+
+install_service() {
+  if [[ -n "${CLOUDFLARE_TUNNEL_TOKEN:-}" ]]; then
+    step "Installation du service cloudflared avec le jeton fourni"
+    cloudflared service install "${CLOUDFLARE_TUNNEL_TOKEN}"
+  else
+    step "Aucun jeton de tunnel fourni"
+    cat <<'EOM'
+${LOG_PREFIX} Vous pouvez fournir un jeton de tunnel via la variable d'environnement
+${LOG_PREFIX} CLOUDFLARE_TUNNEL_TOKEN avant d'exécuter ce script pour configurer
+${LOG_PREFIX} automatiquement le service cloudflared.
+EOM
+  fi
+}
+
+show_agent_information() {
+  step "Informations sur l'agent Cloudflare"
+  local ip_addresses
+  if ip_addresses=$(hostname -I 2>/dev/null); then
+    echo "${LOG_PREFIX} Adresse(s) IP détectée(s) : ${ip_addresses}"
+  else
+    echo "${LOG_PREFIX} Impossible de déterminer les adresses IP via hostname -I" >&2
+  fi
+
+  cat <<'EOM'
+${LOG_PREFIX} Une fois le service installé, vous pouvez gérer le tunnel avec :
+${LOG_PREFIX}   systemctl status cloudflared
+${LOG_PREFIX}   journalctl -u cloudflared -f
+EOM
+}
+
+main() {
+  step "Initialisation de l'installation du tunnel Cloudflare"
+  require_root
+  install_dependencies
+  add_cloudflare_repository
+  install_cloudflared
+  install_service
+  show_agent_information
+  step "Installation terminée"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- allow the Cloudflare tunnel installer script to run non-interactively when fetched remotely
- document how to execute the installer directly with curl, both with and without a tunnel token

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de7e760ec48333a9f6257dc06fcd13